### PR TITLE
use gallery data for media order

### DIFF
--- a/pkg/reddit/link.go
+++ b/pkg/reddit/link.go
@@ -63,6 +63,7 @@ type Link struct {
 	Visited             bool          `json:"visited"`
 
 	MediaMetadata       map[string]MediaMetadata `json:"media_metadata,omitempty"`
+	GalleryData         GalleryData              `json:"gallery_data,omitempty"`
 	CrossPostParentList []Link                   `json:"crosspost_parent_list"`
 }
 
@@ -76,6 +77,15 @@ type MediaMetadataS struct {
 
 type MediaMetadata struct {
 	S MediaMetadataS `json:"s"`
+}
+
+type GalleryDataItem struct {
+	MediaID string `json:"media_id"`
+	ID      int    `json:"id"`
+}
+
+type GalleryData struct {
+	Items []GalleryDataItem `json:"items"`
 }
 
 const linkType = "t3"


### PR DESCRIPTION
Fixes #34 

Currently iterating over `link.MediaMetadata` is subject to [Go's random iteration order for maps](https://go.dev/doc/go1#iteration).

The Reddit JSON provides a `gallery_data` field with the actual order of media. With this PR, `GetArticle` will use the field to write the `img` elements. If the `gallery_data` field is missing, the old iteration order is used.