### PR TITLE
fix!: rename `limit` query param to `scoreLimit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you are interested in using it to you:
 ## query params
 
 -   `?safe=true` filter out nsfw posts
--   `?limit=100` filter out posts with less than 100 up votes
+-   `?scoreLimit=100` filter out posts with less than 100 up votes
 -   `?flair=Energy%20Products` only include posts that have that flair
 
 ## Quick Deploy

--- a/pkg/client/reddit.go
+++ b/pkg/client/reddit.go
@@ -83,7 +83,7 @@ func RssHandler(redditURL string, now NowFn, client *http.Client, getArticle Get
 	}
 
 	var limit int
-	limitStr, scoreLimit := r.URL.Query()["limit"]
+	limitStr, scoreLimit := r.URL.Query()["scoreLimit"]
 	if scoreLimit {
 		limit, err = strconv.Atoi(limitStr[0])
 		if err != nil {


### PR DESCRIPTION
Due to the fact that `limit` is a query param that is actually used by Reddit
itself, it is not a good idea to use `limit` for filtering posts by score, as it
would also limit the amount of results Reddit returns at the same time, and the
result ends up missing a lot of posts.
